### PR TITLE
Ajout d'un warning possible à contourner

### DIFF
--- a/cdpDumpingUtils/main.py
+++ b/cdpDumpingUtils/main.py
@@ -40,6 +40,12 @@ password = None
 
 verbose = False
 
+warning_message = [
+    "Mauvais paramètre d'accès à cette page.",
+    "Ce contenu est protégé. Vous devez vous connecter pour l'afficher.",
+    "Vous n'avez pas accès à cette page."
+]
+
 def start():
     global output_dir, base_url, username, password, verbose
 
@@ -94,7 +100,7 @@ def start():
 
         if sec is not None:
             txt = sec.find("div", "warning")
-            if txt is not None and (txt.string == "Mauvais paramètre d'accès à cette page." or txt.string == "Ce contenu est protégé. Vous devez vous connecter pour l'afficher."):
+            if txt is not None and txt.string in warning_message:
                 return
         else:
             return
@@ -142,7 +148,7 @@ def start():
                 page = BeautifulSoup(dl.text, features="html5lib").find("section")
                 if page is not None:
                     txt = page.find("div", "warning")
-                    if txt is not None and (txt.string == "Mauvais paramètre d'accès à cette page." or txt.string == "Ce contenu est protégé. Vous devez vous connecter pour l'afficher."):
+                    if txt is not None and txt.string in warning_message:
                         access = False
                         nbDocRef += 1
 


### PR DESCRIPTION
En essayant le programme je me suis rendu compte qu'il ne couvrait pas le message d'erreur : `Vous n'avez pas accès à cette page.` ce qui provoquait une erreur car dans les lignes suivantes, il fallait avoir `sec` non nul (l.108).

```python
pages[explore_page] = sec.find("span", "nom").get_text().rstrip()
```

Simple modification qui prends juste plus de cas en compte et qui au lieu d'avoir deux if de 122 caractères, on a une comparaison qui tient sur une ligne (l.103 et l.151)
 
```python
if txt is not None and txt.string in warning_message:
```

ce qui rend plus simple la maintenance avec juste une liste à modifier