### PR TITLE
fix: Updated to match CDP links format

### DIFF
--- a/cdpDumpingUtils/main.py
+++ b/cdpDumpingUtils/main.py
@@ -140,7 +140,7 @@ def start():
         print("Page", p, ":", pages[p].replace(" / ", "/"))
 
         for d in docs[p]:
-            dl = session.get(base_url + "/download?id=" + str(d) + "&dl")
+            dl = session.get(base_url + "/download?id=" + d + "&dl")
             # &dl argument is needed because some documents offers previews
             # (some videos for example)
 

--- a/cdpDumpingUtils/main.py
+++ b/cdpDumpingUtils/main.py
@@ -92,10 +92,12 @@ def start():
 
 
     def explore(explore_page):
-        if verbose:
-            print("Exploring ", base_url + "/docs?rep=" + str(explore_page))
+        url = base_url + "/docs?rep=" + str(explore_page)
         
-        rep = session.get(base_url + "/docs?rep=" + str(explore_page))
+        if verbose:
+            print("Exploring ", url)
+        
+        rep = session.get(url)
         sec = BeautifulSoup(rep.text, features="html5lib").find("section")
 
         if sec is not None:
@@ -107,15 +109,15 @@ def start():
 
         pages[explore_page] = sec.find("span", "nom").get_text().rstrip()
 
-        for r in sec.findAll("a", href=re.compile("rep=")):
+        for r in sec.find_all("a", href=re.compile("rep=")):
             page = int(r["href"].replace("docs", "").replace("?rep=", ""))
             if page not in pages:
                 explore(page)
 
         docs[explore_page] = {}
-        for d in sec.findAll("p", "doc"):
-            id = int(d.find("a", href=re.compile("download"))["href"].replace("download?id=", ""))
-            docs[explore_page][id] = d.find("span", "nom").string
+        for d in sec.find_all("p", "doc"):
+            download_args:str = d.find("a", href=re.compile("download"))["href"].replace("download?id=", "")
+            docs[explore_page][download_args] = d.find("span", "nom").string
 
 
     rep = session.get(base_url)

--- a/cdpDumpingUtils/main.py
+++ b/cdpDumpingUtils/main.py
@@ -116,7 +116,7 @@ def start():
 
         docs[explore_page] = {}
         for d in sec.find_all("p", "doc"):
-            download_args:str = d.find("a", href=re.compile("download"))["href"].replace("download?id=", "")
+            download_args: str = d.find("a", href=re.compile("download"))["href"].replace("download?id=", "")
             docs[explore_page][download_args] = d.find("span", "nom").string
 
 


### PR DESCRIPTION
Hey !

I made a few change, including a **url variable to avoid a little repetition**, and **updating element.findAll to element.find_all due to deprecation** in bs4 4.0 version.

**Here is the main part :**

tl;dr : Cahier de prepa has updated its download links, we just need to put the whole links and it works just as it used to do.

Long boring details :

When running the tool, a fatal error will now occur : 


```
URL de l'instance cahier de prepa : (url)
Connexion avec compte utilisateur ? (y/n): y
Nom d'utilisateur : username
Mot de passe : mdp
cdpDumpingUtils v 0.2.1
Connexion en cours...
Connexion réussie
Exploration de (Cahier) en cours...
Exploring  (url given in input)/docs?rep=0
Exploring  (url given in input)/docs?rep=1
Traceback (most recent call last):
  [... useless trace]
  File "cdpDumpingUtils/main.py", line 119, in explore
    download_args:str = int(d.find("a", href=re.compile("download"))["href"].replace("download?id=", ""))
                        ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '300&v=44da1'
``` 

The error is actually caused by Cahier de prepa downloads href to be updated (i think ?)

From looking at the code I believe that downloads URL used to be in this format : `download?id=314`, where 314 can be any integer, which was stocked in the `id` field of the dictionary `docs[explore_page]`

It seems like CDP now have a version parameter in the URL to download files, which we may want to keep in the download url we will use. The new format is : `download?id=314&v=44da1` with the value of v which I assumed stands for 'version' looks like a random hexadecimal number of 5 digits.

**Actual fix :**
The download argument doesn't need to be an integer, and we just need to put the whole string that comes after `id` in the url. 


 
Anyways, have a good one !